### PR TITLE
Change exit code for too many uniforms from 0 to 1.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -306,7 +306,7 @@ private:
 
     	if (max_supported_uniforms < uniformInfoVec.size()) {
     		std::cerr << "The physical device supports "<< max_supported_uniforms << "uniforms maximum but the JSON file has " << uniformInfoVec.size() <<" uniforms" << std::endl;
-    		exit(0);
+    		exit(1);
     	}
 
     }


### PR DESCRIPTION
Just so that the exit will definitely be detected as an error.